### PR TITLE
Add support for dirty worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ the original branch.
    - With `--onto <branch>` you can modify the branch from which `<new_branch>`
      is based-off.
    - With `--keep` you can keep the last commit on the current branch.
+   - If `--keep` is not given, the commit will be removed from the current
+     branch. This is only safely possible if there are no local modifications.
+     Add `--stash` if you have local changes that you want to temporarily stash.
 
 The new commit and the new branch are both created in memory. This means your
 working directory will not be modified. Unless `--keep` is provided, the staged
@@ -50,7 +53,6 @@ cargo install git-quickfix
 
 ## Known Issues
 
-- A dirty index or modified working directory will likely not work.
 - Default branches from origin are picked up through a hard-coded list. Patches
   welcome.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,20 +69,22 @@ fn run() -> Result<(), Report> {
     let opts = Opt::from_args();
     let repo = Repository::open_from_env()?;
 
-    // Make sure that no rebase / cherry-pick / merge is in progress
-    let state = repo.state();
-    if state != RepositoryState::Clean {
-        return Err(eyre!(
-            "The repository is currently not in a clean state ({:?}).",
-            state
-        ));
-    }
+    if !opts.keep {
+        // Make sure that no rebase / cherry-pick / merge is in progress
+        let state = repo.state();
+        if state != RepositoryState::Clean {
+            return Err(eyre!(
+                "The repository is currently not in a clean state ({:?}).",
+                state
+            ));
+        }
 
-    // Make sure that the work directory has no changes and nothing is staged
-    if !repo.statuses(None)?.is_empty() {
-        return Err(eyre!(
-            "The repository is dirty, aborting. Consider stashing your changes."
-        ));
+        // Make sure that the work directory has no changes and nothing is staged
+        if !repo.statuses(None)?.is_empty() {
+            return Err(eyre!(
+                "The repository is dirty, aborting. Consider stashing your changes."
+            ));
+        }
     }
 
     let onto_branch = match opts.onto {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,13 @@ fn run() -> Result<(), Report> {
         ));
     }
 
+    // Make sure that the work directory has no changes and nothing is staged
+    if !repo.statuses(None)?.is_empty() {
+        return Err(eyre!(
+            "The repository is dirty, aborting. Consider stashing your changes."
+        ));
+    }
+
     let onto_branch = match opts.onto {
         Some(b) => b,
         None => {
@@ -125,7 +132,6 @@ fn run() -> Result<(), Report> {
         opts.branch
     );
 
-    // TODO: What to do if the index or working dir is dirty?
     if !opts.keep {
         // Equivalent to git reset --hard HEAD~1
         if fix_commit.parent_count() != 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::process;
 
-use git2::{self, Repository, ResetType};
+use git2::{self, Repository, RepositoryState, ResetType};
 use process::Command;
 
 use color_eyre::{eyre::Report, eyre::Result, Section};
@@ -68,6 +68,15 @@ struct Opt {
 fn run() -> Result<(), Report> {
     let opts = Opt::from_args();
     let repo = Repository::open_from_env()?;
+
+    // Make sure that no rebase / cherry-pick / merge is in progress
+    let state = repo.state();
+    if state != RepositoryState::Clean {
+        return Err(eyre!(
+            "The repository is currently not in a clean state ({:?}).",
+            state
+        ));
+    }
 
     let onto_branch = match opts.onto {
         Some(b) => b,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,32 +69,17 @@ struct Opt {
         short = "f"
     )]
     force: bool,
+    #[structopt(
+        help = "Automatically stash changes before modifying the current branch.",
+        long = "stash",
+        short = "s"
+    )]
+    stash: bool,
 }
 
-fn run() -> Result<(), Report> {
-    let opts = Opt::from_args();
-    let repo = Repository::open_from_env()?;
-
-    if !opts.keep {
-        // Make sure that no rebase / cherry-pick / merge is in progress
-        let state = repo.state();
-        if state != RepositoryState::Clean {
-            return Err(eyre!(
-                "The repository is currently not in a clean state ({:?}).",
-                state
-            ));
-        }
-
-        // Make sure that the work directory has no changes and nothing is staged
-        if !repo.statuses(None)?.is_empty() {
-            return Err(eyre!(
-                "The repository is dirty, aborting. Consider stashing your changes."
-            ));
-        }
-    }
-
-    let onto_branch = match opts.onto {
-        Some(b) => b,
+fn cherrypick_commit_onto_new_branch(repo: &Repository, opts: &Opt) -> Result<(), Report> {
+    let onto_branch = match &opts.onto {
+        Some(b) => b.clone(),
         None => {
             get_default_branch(&repo).suggestion("Manually set the target branch with `--onto`.")?
         }
@@ -114,6 +99,10 @@ fn run() -> Result<(), Report> {
     // Cherry-pick the HEAD onto the main branch but in memory.
     // Then create a new branch with that cherry-picked commit.
     let fix_commit = repo.head()?.peel_to_commit()?;
+    if fix_commit.parent_count() != 1 {
+        return Err(eyre!("Only works with non-merge commits"))
+            .suggestion("Quickfixing a merge commit is not supported. If you meant to do this please file a ticket with your usecase.");
+    };
 
     // Cherry-pick (in memory)
     let mut index = repo.cherrypick_commit(&fix_commit, &main_commit, 0, None)?;
@@ -145,27 +134,84 @@ fn run() -> Result<(), Report> {
         opts.branch
     );
 
-    if !opts.keep {
-        // Equivalent to git reset --hard HEAD~1
-        if fix_commit.parent_count() != 1 {
-            return Err(eyre!("Only works with non-merge commits"))
-                .suggestion("Quickfixing a merge commit is not supported. If you meant to do this please file a ticket with your usecase.");
-        };
-        let head_1 = fix_commit.parent(0)?;
-        repo.reset(&head_1.as_object(), ResetType::Hard, None)?;
+    Ok(())
+}
+
+fn remove_commit(repo: &mut Repository, opts: &Opt, is_dirty: bool) -> Result<(), Report> {
+    if is_dirty {
+        // We should only get here if stashing is enabled
+        assert!(opts.stash);
+
+        // Stash everything
+        repo.stash_save(&repo.signature().unwrap(), "auto-stash: quickfix", None)?;
+    }
+    // Equivalent to git reset --hard HEAD~1
+    let head_1 = repo.head()?.peel_to_commit()?.parent(0)?;
+    repo.reset(&head_1.as_object(), ResetType::Hard, None)?;
+    drop(head_1);
+
+    if is_dirty {
+        // apply the staged changes
+        repo.stash_apply(0, None)?;
     }
 
+    Ok(())
+}
+
+fn push_new_commit(_repo: &Repository, opts: &Opt) -> Result<(), Report> {
     // TODO: Use git2 instead of Command.
-    if opts.push {
-        log::info!("Pushing new branch to origin.");
-        let status = Command::new("git")
-            .args(&["push", "--set-upstream", "origin", &opts.branch])
-            .status()?;
-        if !status.success() {
-            eyre!("Failed to run git push. {}", status);
-        } else {
-            log::info!("Git push succeeded");
+    log::info!("Pushing new branch to origin.");
+    let status = Command::new("git")
+        .args(&["push", "--set-upstream", "origin", &opts.branch])
+        .status()?;
+    if !status.success() {
+        eyre!("Failed to run git push. {}", status);
+    } else {
+        log::info!("Git push succeeded");
+    }
+
+    Ok(())
+}
+
+fn can_commit_be_kept(repo: &Repository, opts: &Opt) -> Result<bool, Report> {
+    if opts.keep {
+        // If we keep the commit, the repository state does not matter
+        Ok(true)
+    } else {
+        // Make sure that no rebase / cherry-pick / merge is in progress
+        let state = repo.state();
+        if state != RepositoryState::Clean {
+            return Err(eyre!(
+                "The repository is currently not in a clean state ({:?}).",
+                state
+            ));
         }
+
+        let is_dirty = !repo.statuses(None)?.is_empty();
+        if is_dirty && !opts.stash {
+            // Make sure that the work directory has no changes and nothing is staged
+            return Err(eyre!(
+                "The repository is dirty, aborting. Consider auto-stashing your changes with --stash."
+            ));
+        }
+        Ok(is_dirty)
+    }
+}
+
+fn run() -> Result<(), Report> {
+    let opts = Opt::from_args();
+    let mut repo = Repository::open_from_env()?;
+
+    let is_dirty = can_commit_be_kept(&repo, &opts)?;
+
+    cherrypick_commit_onto_new_branch(&repo, &opts)?;
+
+    if !opts.keep {
+        remove_commit(&mut repo, &opts, is_dirty)?
+    }
+
+    if opts.push {
+        push_new_commit(&repo, &opts)?;
     }
 
     Ok(())


### PR DESCRIPTION
Hey @siedentop,

thank you for this nice git extension!

I noticed that local changes in the repository are `reset` if the `--keep` flag is not specified, as
```rust
repo.reset(&head_1.as_object(), ResetType::Hard, None)?;
```
performs a hard reset on the HEAD.

As this could lead to lost work, I propose a few tweaks / features:
1. Check if the worktree is dirty, refuse to do anything in this case, except for ...
2. ...when the proposed `--autostash` flag is given, in which case a temporary stash is created like with `rebase.autoStash`.
3. Create the target branch before performing the cherry pick, to keep the `main` branch unmodified

(3. is actually independent of the other changes, but greatly helps with repeatedly running the command.)

I have also split the command into several functions, because the `stash_...` functions required a `&mut Repository` and this way explicit `drop(...)` invocations can be avoided.

I'm happy to continue working on this, If you'd like to keep any of these features.

Cheers