### PR TITLE
Default to `--keep`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to
 
 ### Changed
 
-- The option `--stash` has been renamed to `--autostash`. Issue #9
+- The option `--stash` has been renamed to `--autostash`. [Issue #9](https://github.com/siedentop/git-quickfix/issues/9)
+- The option `--keep` is now the default, and the opposite is now called `--remove`.
+Providing `--remove` will now drop the commit from the original branch. By default, the commit
+stays on the branch. [Issue #10](https://github.com/siedentop/git-quickfix/issues/8)
 
 ### Removed
 - Removed the `qf` alias. All votes were in favor [1].

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ the original branch.
 3. `git quickfix --help` provides more options.
    - With `--onto <branch>` you can modify the branch from which `<new_branch>`
      is based-off.
-   - With `--keep` you can keep the last commit on the current branch.
-   - If `--keep` is not given, the commit will be removed from the current
-     branch. This is only safely possible if there are no local modifications.
-     Add `--autostash` if you have local changes that you want to temporarily stash.
+   - With `--remove` the last commit will be removed from the original branch.
+   - Add `--autostash` if you have local changes that you want to temporarily stash.
 
 The cherry-pick is done in memory. This means your working directory will not be
-modified. Unless `--keep` is provided, the quickfix commit will be removed.
+modified.
+
+The quickfix commit will be kept (changed in v0.0.5) unless `--remove` is provided.
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,13 +35,11 @@ fn run() -> Result<(), Report> {
 
     // TODO: Make this an integration test.
     // assert:
-    // * keep is true.
+    // * remove is false.
     // * OR: repo is clean.
     // *     OR: stash is enabled
 
-    if opts.keep {
-        cherrypick_commit_onto_new_branch(&repo, &target_branch, &onto_branch, opts.force)?;
-    } else {
+    if opts.remove {
         let stashed = if opts.stash { stash(&mut repo)? } else { false };
 
         let result = wrapper_pick_and_clean(&repo, &target_branch, &onto_branch, opts.force);
@@ -49,6 +47,8 @@ fn run() -> Result<(), Report> {
             repo.stash_pop(0, None)?
         };
         let _ = result?;
+    } else {
+        cherrypick_commit_onto_new_branch(&repo, &target_branch, &onto_branch, opts.force)?;
     }
 
     if opts.push {
@@ -70,8 +70,7 @@ fn run() -> Result<(), Report> {
 /// 1. Commit the changes
 /// 2. git quickfix <new-branch>. This will create a new branch from the default branch.
 ///     `--push` will directly push this to the `origin` remote.
-///     `--keep` will keep the quickfix commit on the current branch.
-/// 3. The changes will be removed from the current branch, unless `--keep` was given to quickfix.
+///     `--remove` will remove the quickfix commit from the current branch.
 ///
 /// Benefits: Quickly provide unrelated fixes without having to abandon the current branch and switching branches.
 #[derive(Debug, StructOpt)]
@@ -91,11 +90,10 @@ struct Opt {
     )]
     push: bool,
     #[structopt(
-        long = "keep",
-        short = "k",
-        help = "Keep the new quickfix commit on the current branch."
+        long = "remove",
+        help = "Remove the new quickfix commit from the current (original) branch."
     )]
-    keep: bool,
+    remove: bool,
     #[structopt(
         help = "The starting point onto which the quickfix gets applied. Defaults to the default branch on origin (e.g. origin/main).",
         long = "onto",


### PR DESCRIPTION
The new "no-keep" option is called `--remove`.

Thanks to @sharkdp & @betwo for their comments.

Closes #8.